### PR TITLE
Fix the chart width and height

### DIFF
--- a/MMM-WeatherChart.js
+++ b/MMM-WeatherChart.js
@@ -537,6 +537,7 @@ Module.register("MMM-WeatherChart", {
                     datasets: dataset.datasets
                 },
                 options: {
+                    maintainAspectRatio: false,
                     title: {
                         display: true,
                         text: this.config.title


### PR DESCRIPTION
The width and height setting do not work well because
Chart.js fixes the chart width and height ratio to 2 by default [1].

To solve that, I set maintainAspectRatio as false.

Related issue:
https://github.com/mtatsuma/MMM-WeatherChart/issues/21

[1] https://www.chartjs.org/docs/latest/general/responsive.html#configuration-options