### PR TITLE
Modify the margin between chart lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ You can check [available MMM-WeatherChart versions](https://github.com/mtatsuma/
 | units | | `standard` | Units of measurement documented in [OpenWeather API document](https://openweathermap.org/api/one-call-api). `standard`, `metric` and `imperial` units are available. |
 | chartjsVersion | | `3.4.0` | Version of [Chart.js](https://www.chartjs.org/) |
 | chartjsDatalabelsVersion | | `2.0.0` | Version of Chart.js [Datalabels plugin](https://github.com/chartjs/chartjs-plugin-datalabels) |
-| height | | `300px` | Height of the chart area |
-| width | | `500px` | Width of the chart area |
+| height | | `300px` | Height of the chart area in px |
+| width | | `500px` | Width of the chart area in px |
 | fontSize | | `16` | Font size of characters in the chart |
 | fontWeight | | `normal` | Font weight of characters in the chart. See https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight for checking available values. |
 | timeOffsetHours | | `0` | Offset in hours. This is used when your timezone is different from the timezone set in MagicMirror server. |


### PR DESCRIPTION
Icon images and data labels may overlap with each other
when the chart height is small (e.g. < 300px).

This commit enables to set the mergin based on
the chart height, font size and data labels offset values.

To calculate the margins, the "height" config must be in px.
Then I updated README to note that it must be in px.

Related issue:
https://github.com/mtatsuma/MMM-WeatherChart/issues/38