### PR TITLE
Option to show UV index in hourly chart

### DIFF
--- a/MMM-WeatherChart.js
+++ b/MMM-WeatherChart.js
@@ -326,6 +326,7 @@ Module.register("MMM-WeatherChart", {
         let dayTime;
         for (let i = 0; i < Math.min(this.config.dataNum, data.length); i++) {
             pressures.push(this.getPressureValue(data[i].pressure));
+            uvis.push(data[i].pressure);
 
             let dateTime = new Date(
                 data[i].dt * 1000 + this.config.timeOffsetHours * 60 * 60 * 1000

--- a/MMM-WeatherChart.js
+++ b/MMM-WeatherChart.js
@@ -326,7 +326,7 @@ Module.register("MMM-WeatherChart", {
         let dayTime;
         for (let i = 0; i < Math.min(this.config.dataNum, data.length); i++) {
             pressures.push(this.getPressureValue(data[i].pressure));
-            uvis.push(data[i].pressure);
+            uvis.push(data[i].uvi);
 
             let dateTime = new Date(
                 data[i].dt * 1000 + this.config.timeOffsetHours * 60 * 60 * 1000

--- a/MMM-WeatherChart.js
+++ b/MMM-WeatherChart.js
@@ -315,7 +315,7 @@ Module.register("MMM-WeatherChart", {
             nightTemps = [NaN],
             labels = [""],
             iconIDs = [NaN],
-            pressures = [NaN];
+            pressures = [NaN],
             uvis = [NaN];
 
         data.sort(function (a, b) {

--- a/MMM-WeatherChart.js
+++ b/MMM-WeatherChart.js
@@ -36,6 +36,7 @@ Module.register("MMM-WeatherChart", {
         showIcon: false,
         showPressure: false,
         showRain: false,
+        showUV: false,
         showZeroRain: true,
         rainUnit: "mm",
         rainMinHeight: 0.01,
@@ -315,6 +316,7 @@ Module.register("MMM-WeatherChart", {
             labels = [""],
             iconIDs = [NaN],
             pressures = [NaN];
+            uvis = [NaN];
 
         data.sort(function (a, b) {
             if (a.dt < b.dt) return -1;
@@ -386,6 +388,7 @@ Module.register("MMM-WeatherChart", {
         labels.push("");
         iconIDs.push(NaN);
         pressures.push(NaN);
+        uvis.push(NaN);
 
         const minTemp = this.getMin(temps),
             maxTemp = this.getMax(temps),
@@ -393,6 +396,7 @@ Module.register("MMM-WeatherChart", {
             maxSnow = this.getMax(snows),
             maxPressure = this.getMax(pressures),
             minPressure = this.getMin(pressures),
+            maxUV = this.getMax(uvis),
             iconLine = [],
             icons = [];
 
@@ -539,6 +543,33 @@ Module.register("MMM-WeatherChart", {
                 });
             }
         }
+        if (this.config.showUV) {
+                datasets.push({
+                    label: "UV Index",
+                    backgroundColor: this.config.fillColor,
+                    borderColor: this.config.color,
+                    borderWidth: 1,
+                    pointBackgroundColor: this.config.color,
+                    datalabels: {
+                        color: this.config.color,
+                        align: "top",
+                        offset: this.config.datalabelsOffset,
+                        font: {
+                            weight: this.config.fontWeight,
+                        },
+                        display: this.config.datalabelsDisplay,
+                        formatter: function (value) {
+                            let place =
+                                10 ** self.config.datalabelsRoundDecimalPlace;
+                            let label = Math.round(value * place) / place;
+                            return label
+                        },
+                    },
+                    data: uvis,
+                    fill: true,
+                    yAxisID: "y2",
+                });
+        }
         if (this.config.showSnow) {
             if (this.config.showZeroSnow || maxSnow > 0) {
                 datasets.push({
@@ -581,7 +612,7 @@ Module.register("MMM-WeatherChart", {
         let y1_max = iconLine[0] + (maxTemp - minTemp) * iconTopMargin,
             y1_min = minTemp - (maxTemp - minTemp) * tempRainMargin,
             y2_max =
-                Math.max(maxRain, maxSnow, this.config.rainMinHeight) *
+                Math.max(maxRain, maxSnow, maxUV, this.config.rainMinHeight) *
                 (2 + iconTopMargin + iconBelowMargin + tempRainMargin),
             y2_min = 0,
             y3_min = minPressure - (maxPressure - minPressure) * 0.1,

--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ You can check [available MMM-WeatherChart versions](https://github.com/mtatsuma/
                 "showRain": true,
                 "includeSnow": true,
                 "showSnow": true,
-                "showIcon": true
+                "showIcon": true,
+                "showUV": true
             }
         }
    ]
@@ -83,6 +84,7 @@ You can check [available MMM-WeatherChart versions](https://github.com/mtatsuma/
 | nightBorderDash | | `[5, 1]` | Style of dash line for nighttime (`[<line length>, <blank length>]`). This option is available only for `hourly` data type. |
 | showIcon | | `false` | Show weather Icon on the top |
 | showRain | | `false` | Show rain volume on the bottom |
+| showUV | | `false` | Show UV Index |
 | showZeroRain | | `true` | Show rain chart even when there is no rain volume. This option is effective only when `showRain` is true. |
 | rainUnit | | `mm` | Unit of rain volume (`mm` or `inch`) |
 | rainMinHeight | | `0.01` | Minimum height (in mm or inch) of the rain volume chart. When the max rain volume in the chart is less than this value, the height of chart is set as this value. Otherwise, the height of the chart is set acoording to the max rain volume. |


### PR DESCRIPTION
Setting `showUV = true` in the configuration displays the 12-hour UV forecast. Only works for hourly weather.