### PR TITLE
Update OpenWeather API default version

### DIFF
--- a/MMM-WeatherChart.js
+++ b/MMM-WeatherChart.js
@@ -13,7 +13,7 @@ Module.register("MMM-WeatherChart", {
         updateInterval: 10 * 60 * 1000,
         retryDelay: 5000,
         apiBase: "https://api.openweathermap.org/data/",
-        apiVersion: "2.5",
+        apiVersion: "3.0",
         apiEndpoint: "onecall",
         apiKey: "",
         lat: "",

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ You can check [available MMM-WeatherChart versions](https://github.com/mtatsuma/
 | updateInterval | | `10 * 60 * 1000` | Weather data update interval (miliseconds) |
 | retryDelay | | `5 * 1000` | Delay for retry to get weather data (miliseconds) |
 | apiBase | | `https://api.openweathermap.org/data/` | Base URL of [OpenWeather](https://openweathermap.org/) API |
-| apiVersion | | `2.5` | Version of [OpenWeather](https://openweathermap.org/) API |
+| apiVersion | | `3.0` | Version of [OpenWeather](https://openweathermap.org/) API |
 | apiEndpoint | | `onecall` | [OpenWeather](https://openweathermap.org/) API endpoint. [One Call API](https://openweathermap.org/api/one-call-api) is used by default, which is available for Free subscription. Note: Don't change this option because other endpoint is not supported! |
 | apiKey | yes | | API key to call [OpenWeather](https://openweathermap.org/) API. You can get the API key by signing up [OpenWeather](https://openweathermap.org/). |
 | lat | yes | | latitude of the place you want to get weather information |


### PR DESCRIPTION
2.5 version of OpenWeather API is no longer available.